### PR TITLE
Get updated ticket sales data on page load

### DIFF
--- a/content/_data/shows.js
+++ b/content/_data/shows.js
@@ -14,6 +14,7 @@ module.exports = async function() {
       body,
       featured,
       onsale,
+      "id": _id,
       "slug": slug.current,
       "tags": tags[]->title,
       "date": premierDate,
@@ -38,6 +39,7 @@ module.exports = async function() {
       show.run = show.run.map((perf) => {
         perf.seats = perf.seats || 25;
         perf.sold = perf.tickets.reduce((sold, tix) => sold + tix, 0);
+        perf.onSale = Math.max(perf.seats - perf.sold, 0);
         return perf;
       });
     }

--- a/content/_includes/checkout.js
+++ b/content/_includes/checkout.js
@@ -1,0 +1,58 @@
+const eventSelect = document.getElementById('field-product');
+const countInput = document.getElementById('field-count');
+const maxInput = document.getElementById('max');
+
+const priceInput = document.getElementById('field-price');
+const priceTotal = document.getElementById('total-price-output');
+
+const updateTotal = () => {
+  if (priceInput.value && countInput.value) {
+    const total = Number(priceInput.value * countInput.value).toFixed(2);
+    priceTotal.value = `$${total}`;
+  } else {
+    priceTotal.value = 'n/a';
+  }
+}
+
+const getOnSale = (event) => {
+  const data = tickets.find((ticket) => ticket.event === event);
+  return data.onSale;
+}
+
+const updateLimit = () => {
+  const val = eventSelect.value.split('@event@');
+  const perf = val[1];
+  const max = getOnSale(perf);
+
+  countInput.setAttribute('max', max);
+  maxInput.setAttribute('value', max);
+}
+
+const updateTicketInfo = (data) => {
+  tickets.forEach((ticket, index) => {
+    const newData = data.find((item) => ticket.event === item.event);
+    if (newData) { tickets[index] = {...ticket, ...newData}; }
+  });
+}
+
+const getTicketInfo = async () => {
+  const response = await fetch(
+    '/api/tickets/?' + new URLSearchParams({ show })
+  );
+  const data = await response.json();
+  return data.data;
+}
+
+const refreshData = async () => {
+  const info = await getTicketInfo();
+  updateTicketInfo(info);
+  updateLimit();
+}
+
+window.onload = async () => {
+  countInput.addEventListener('change', () => updateTotal());
+  priceInput.addEventListener('change', () => updateTotal());
+  eventSelect.addEventListener('change', () => updateLimit());
+
+  await refreshData();
+};

--- a/content/_includes/checkout.macros.njk
+++ b/content/_includes/checkout.macros.njk
@@ -8,12 +8,12 @@
       and values are used for display
 #}
 {% macro flexible(
+  show_id,
   tickets,
   suggested=none
 ) %}
   <form action="/api/checkout" method="POST">
-    {%- set seats = tickets | getOptions('value', 'seats') -%}
-    {%- set max = tickets[0]['seats'] -%}
+    {%- set max = tickets[0]['onSale'] -%}
 
     {{- form.input(
       id='max',
@@ -71,31 +71,8 @@
     </div>
   </form>
   <script type='module'>
-    const seats = {{ seats | jsonify | safe }};
-
-    const eventSelect = document.getElementById('field-product');
-    const countInput = document.getElementById('field-count');
-    const maxInput = document.getElementById('max');
-
-    const priceInput = document.getElementById('field-price');
-    const priceTotal = document.getElementById('total-price-output');
-
-    eventSelect.addEventListener('change', () => {
-      const max = seats[eventSelect.value];
-      countInput.setAttribute('max', max);
-      maxInput.setAttribute('value', max);
-    });
-
-    const updateTotal = () => {
-      if (priceInput.value && countInput.value) {
-        const total = Number(priceInput.value * countInput.value).toFixed(2);
-        priceTotal.value = `$${total}`;
-      } else {
-        priceTotal.value = 'n/a';
-      }
-    }
-
-    countInput.addEventListener('change', () => updateTotal());
-    priceInput.addEventListener('change', () => updateTotal());
+    const tickets = {{ tickets | jsonify | safe }};
+    const show = '{{ show_id }}';
+    {% include "checkout.js" %}
   </script>
 {% endmacro %}

--- a/content/shows/show.njk
+++ b/content/shows/show.njk
@@ -40,6 +40,7 @@ eleventyComputed:
         We'll be in touch if the situation changes.
       </li>
     </ul>
-    {{ checkout.flexible(tickets) }}
+
+    {{ checkout.flexible(show.id, tickets) }}
   </section>
 {% endif %}

--- a/filters/forms.js
+++ b/filters/forms.js
@@ -19,17 +19,18 @@ const showTickets = (run, products) => {
 
   return run.map((perf) => {
     const ticket = _.find(products, ['metadata.sanity_id', perf.id]);
-    let seats = perf.seats - perf.sold;
-    seats = seats > 0 ? seats : null;
+    const onSale = perf.seats - perf.sold;
 
     return {
-      ticket,
-      seats,
+      ticket: ticket ? ticket.id : null,
       event: perf.id,
+      seats: perf.seats,
+      sold: perf.sold,
+      onSale: onSale > 0 ? onSale : null,
       value: ticket ? `${ticket.id}@event@${perf.id}` : null,
       display: `${date(perf.date, 'show')}`,
     };
-  }).filter((perf) => perf.seats && perf.ticket);
+  }).filter((perf) => perf.onSale && perf.ticket);
 }
 
 module.exports = {

--- a/functions/checkout.js
+++ b/functions/checkout.js
@@ -34,7 +34,7 @@ exports.handler = async function (event, context) {
         && references(^._id)
       ]{ "sold": numberOfTickets }[].sold
     }
-  `)
+  `);
 
   const seats = eventData.seats || 25;
   const sold = eventData.tickets.reduce((sold, tix) => sold + tix, 0);

--- a/functions/tickets.js
+++ b/functions/tickets.js
@@ -1,0 +1,38 @@
+const groq = require('groq');
+const client = require('../utils/sanityClient');
+
+exports.handler = async (event, context) => {
+  try {
+    const showID = event.queryStringParameters.show;
+
+    const show = await client.fetch(groq`
+      *[_id == "${showID}"][0]{
+        "run": performance[]->{
+          seats,
+          "id": _id,
+          "tickets": *[_type == "ticket"
+            && !(_id in path("drafts.**"))
+            && references(^._id)
+          ]{ "sold": numberOfTickets }[].sold
+        },
+      }
+    `);
+
+    const data = show.run.map((perf) => {
+      const seats = perf.seats || 25;
+      const sold = perf.tickets.reduce((sold, tix) => sold + tix, 0);
+      const onSale = Math.max(seats - sold, 0);
+      return {
+        event: perf.id,
+        seats, sold, onSale,
+      };
+    });
+    return { statusCode: 200, body: JSON.stringify({ data }) };
+  } catch (error) {
+    console.log(error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed fetching data' }),
+    };
+  }
+};


### PR DESCRIPTION
- added an `/api/tickets/` serverless function that returns ticket-sales for a show
- show pages with ticket sales are built using the ticket data at build time 
- they also fetch updated data for the show on `window.onload`
- when you select a show in the list, the max available limits are updated
- the stripe checkout flow also checks for up-to-date ticket sales

Is that overkill?